### PR TITLE
Corrections for March EOS EVM March release

### DIFF
--- a/docs/50_eos-evm/20_eos-evm-network/30_resources.md
+++ b/docs/50_eos-evm/20_eos-evm-network/30_resources.md
@@ -1,17 +1,17 @@
 ---
-title: Resources
+title: Helpful Links
 ---
 
-## Endpoints
+### EOS EVM Testnet
 
-* Main RPC URL: [https://api.testnet.evm.eosnetwork.com](https://api.testnet.evm.eosnetwork.com)
+* Testnet RPC URL: [https://api.testnet.evm.eosnetwork.com](https://api.testnet.evm.eosnetwork.com).
+* Testnet EOS EVM Explorer: [https://explorer.testnet.evm.eosnetwork.com/](https://explorer.testnet.evm.eosnetwork.com/).
+* Testnet Faucet: [https://faucet.testnet.evm.eosnetwork.com](https://faucet.testnet.evm.eosnetwork.com).
+
+### Community
+
+* EOS EVM Developers Telegram: [https://t.me/eosevm](https://t.me/eosevm).
+
+### Miscellaneous
 
 For EOS EVM testnet you can use the configuration listed at [Chainlist.org](https://chainlist.org/).
-
-## EOS EVM Blockchain Explorer
-
-* [EOS EVM Explorer](https://explorer.testnet.evm.eosnetwork.com/)
-
-## Faucet
-
-* EVM Token: [`https://faucet.testnet.evm.eosnetwork.com/`](https://faucet.testnet.evm.eosnetwork.com/)

--- a/docs/50_eos-evm/20_eos-evm-network/30_resources.md
+++ b/docs/50_eos-evm/20_eos-evm-network/30_resources.md
@@ -2,16 +2,16 @@
 title: Helpful Links
 ---
 
-### EOS EVM Testnet
+#### EOS EVM Testnet
 
 * Testnet RPC URL: [https://api.testnet.evm.eosnetwork.com](https://api.testnet.evm.eosnetwork.com).
 * Testnet EOS EVM Explorer: [https://explorer.testnet.evm.eosnetwork.com/](https://explorer.testnet.evm.eosnetwork.com/).
 * Testnet Faucet: [https://faucet.testnet.evm.eosnetwork.com](https://faucet.testnet.evm.eosnetwork.com).
 
-### Community
+#### Community
 
 * EOS EVM Developers Telegram: [https://t.me/eosevm](https://t.me/eosevm).
 
-### Miscellaneous
+#### Miscellaneous
 
 For EOS EVM testnet you can use the configuration listed at [Chainlist.org](https://chainlist.org/).

--- a/docs/50_eos-evm/30_developer-guide/50_develop-eos-evm-smart-contracts-with-remix.md
+++ b/docs/50_eos-evm/30_developer-guide/50_develop-eos-evm-smart-contracts-with-remix.md
@@ -52,9 +52,9 @@ You will return to this panel later, after you deploy the smart contract, and al
 
 To connect the Remix IDE to the EOS EVM network you must first [connect your metamask wallet](../20_eos-evm-network/20_connect-metamask.md) to the EOS EVM network. You can connect to the EOS EVM main network or you can connect to any of the available EOS EVM test networks. For information about available EOS EVM networks please consult the [resources page](../20_eos-evm-network/30_resources.md).
 
-### Have Enough EMV Tokens
+### Have Enough EOS Tokens
 
-You also must ensure you have EVM tokens available in your wallet to be able to cover the transactions costs. If you use the EOS EVM test network you can use the [faucet](https://faucet.testnet.evm.eosnetwork.com) to get some EVM tokens. If you use the EOS EVM main network you must transfer tokens from a different address or swap them from EOS tokens or any other available tokens.
+You also must ensure you have EOS tokens available in your wallet to be able to cover the transactions costs. If you use the EOS EVM test network you can use the [faucet](https://faucet.testnet.evm.eosnetwork.com) to get some EOS tokens. If you use the EOS EVM main network you must transfer tokens from a different address or swap them from EOS tokens or any other available tokens.
 
 ### Connect the Remix IDE To EOS EVM
 


### PR DESCRIPTION
EVM Token -> EOS Token
Resources page -> Helpful Links page

I did not rename the Resources page md file, for March release we can live with it; however for April release I will rename that file name from resources.md to helpful_links.md as well not just its content title.

here's how the Helpful Links page renders:

<img width="658" alt="image" src="https://user-images.githubusercontent.com/11767353/229294675-b9ca41da-e303-4828-84fd-440e622128c3.png">
