### PR TITLE
corrections: show the c++ built-in types

### DIFF
--- a/docs/20_smart-contracts/10_getting-started/40_smart_contract_basics.md
+++ b/docs/20_smart-contracts/10_getting-started/40_smart_contract_basics.md
@@ -228,54 +228,62 @@ This is the full list of built-in types:
 
 | Integral Types | Description |
 | --- | --- |
+| Header file to include | `<eosio/eosio.hpp>` |
 | `bool` | Boolean (true/false) |
-| `int8` | Signed 8-bit integer |
-| `uint8` | Unsigned 8-bit integer |
-| `int16` | Signed 16-bit integer |
-| `uint16` | Unsigned 16-bit integer |
-| `int32` | Signed 32-bit integer |
-| `uint32` | Unsigned 32-bit integer |
-| `int64` | Signed 64-bit integer |
-| `uint64` | Unsigned 64-bit integer |
-| `int128` | Signed 128-bit integer |
-| `uint128` | Unsigned 128-bit integer |
-| `varint32` | Variable-length signed 32-bit integer |
-| `varuint32` | Variable-length unsigned 32-bit integer |
+| `int8_t` | Signed 8-bit integer |
+| `uint8_t` | Unsigned 8-bit integer |
+| `int16_t` | Signed 16-bit integer |
+| `uint16_t` | Unsigned 16-bit integer |
+| `int32_t` | Signed 32-bit integer |
+| `uint32_t` | Unsigned 32-bit integer |
+| `int64_t` | Signed 64-bit integer |
+| `uint64_t` | Unsigned 64-bit integer |
+| `int128_t` | Signed 128-bit integer |
+| `uint128_t` | Unsigned 128-bit integer |
+| `signed_int` | Variable-length signed 32-bit integer |
+| `unsigned_int` | Variable-length unsigned 32-bit integer |
 
 | Float Types | Description |
 | --- | --- |
-| `float32` | 32-bit floating-point number |
-| `float64` | 64-bit floating-point number |
+| Header file to include | `<eosio/eosio.hpp>` |
+| `float` | 32-bit floating-point number |
+| `double` | 64-bit floating-point number |
 | `float128` | 128-bit floating-point number |
 
 | Time Types | Description |
 | --- | --- |
+| Header file to include | `<eosio/eosio.hpp>` |
 | `time_point` | Point in time |
 | `time_point_sec` | Point in time with second precision |
 | `block_timestamp_type` | Block timestamp |
 
 | Name Type | Description |
 | --- | --- |
+| Header file to include | `<eosio/eosio.hpp>` |
 | `name` | Account name |
 
 | Blob Types | Description |
 | --- | --- |
+| Header file to include | `<eosio/eosio.hpp>` |
 | `bytes` | Raw byte sequence |
 | `string` | String |
 
 | Checksum Types | Description |
 | --- | --- |
+| Header file to include | `<eosio/eosio.hpp>` |
 | `checksum160` | 160-bit checksum |
 | `checksum256` | 256-bit checksum |
 | `checksum512` | 512-bit checksum |
 
 | Cryptography Types | Description |
 | --- | --- |
+| Header file to include | `<eosio/crypto.hpp>` |
 | `public_key` | Public key |
 | `signature` | Signature |
 
 | Asset Types | Description |
 | --- | --- |
+| Header file to include | `<eosio/asset.hpp>` |
 | `symbol` | Asset symbol |
 | `symbol_code` | Asset symbol code |
 | `asset` | Asset |

--- a/docs/20_smart-contracts/10_getting-started/40_smart_contract_basics.md
+++ b/docs/20_smart-contracts/10_getting-started/40_smart_contract_basics.md
@@ -228,30 +228,30 @@ This is the full list of built-in types:
 
 | Integral Types | Description |
 | --- | --- |
-| `uint8_t` | Boolean (true/false) |
-| `int8_t` | Signed 8-bit integer |
-| `uint8_t` | Unsigned 8-bit integer |
-| `int16_t` | Signed 16-bit integer |
-| `uint16_t` | Unsigned 16-bit integer |
-| `int32_t` | Signed 32-bit integer |
-| `uint32_t` | Unsigned 32-bit integer |
-| `int64_t` | Signed 64-bit integer |
-| `uint64_t` | Unsigned 64-bit integer |
-| `int128_t` | Signed 128-bit integer |
-| `uint128_t` | Unsigned 128-bit integer |
-| `fc::signed_int` | Variable-length signed 32-bit integer |
-| `fc::unsigned_int` | Variable-length unsigned 32-bit integer |
+| `bool` | Boolean (true/false) |
+| `int8` | Signed 8-bit integer |
+| `uint8` | Unsigned 8-bit integer |
+| `int16` | Signed 16-bit integer |
+| `uint16` | Unsigned 16-bit integer |
+| `int32` | Signed 32-bit integer |
+| `uint32` | Unsigned 32-bit integer |
+| `int64` | Signed 64-bit integer |
+| `uint64` | Unsigned 64-bit integer |
+| `int128` | Signed 128-bit integer |
+| `uint128` | Unsigned 128-bit integer |
+| `varint32` | Variable-length signed 32-bit integer |
+| `varuint32` | Variable-length unsigned 32-bit integer |
 
 | Float Types | Description |
 | --- | --- |
-| `float` | 32-bit floating-point number |
-| `double` | 64-bit floating-point number |
-| `float128_t` | 128-bit floating-point number |
+| `float32` | 32-bit floating-point number |
+| `float64` | 64-bit floating-point number |
+| `float128` | 128-bit floating-point number |
 
 | Time Types | Description |
 | --- | --- |
-| `fc::time_point` | Point in time |
-| `fc::time_point_sec` | Point in time with second precision |
+| `time_point` | Point in time |
+| `time_point_sec` | Point in time with second precision |
 | `block_timestamp_type` | Block timestamp |
 
 | Name Type | Description |
@@ -265,14 +265,14 @@ This is the full list of built-in types:
 
 | Checksum Types | Description |
 | --- | --- |
-| `checksum160_type` | 160-bit checksum |
-| `checksum256_type` | 256-bit checksum |
-| `checksum512_type` | 512-bit checksum |
+| `checksum160` | 160-bit checksum |
+| `checksum256` | 256-bit checksum |
+| `checksum512` | 512-bit checksum |
 
 | Cryptography Types | Description |
 | --- | --- |
-| `public_key_type` | Public key |
-| `signature_type` | Signature |
+| `public_key` | Public key |
+| `signature` | Signature |
 
 | Asset Types | Description |
 | --- | --- |

--- a/docs/20_smart-contracts/10_getting-started/40_smart_contract_basics.md
+++ b/docs/20_smart-contracts/10_getting-started/40_smart_contract_basics.md
@@ -228,30 +228,30 @@ This is the full list of built-in types:
 
 | Integral Types | Description |
 | --- | --- |
-| `bool` | Boolean (true/false) |
-| `int8` | Signed 8-bit integer |
-| `uint8` | Unsigned 8-bit integer |
-| `int16` | Signed 16-bit integer |
-| `uint16` | Unsigned 16-bit integer |
-| `int32` | Signed 32-bit integer |
-| `uint32` | Unsigned 32-bit integer |
-| `int64` | Signed 64-bit integer |
-| `uint64` | Unsigned 64-bit integer |
-| `int128` | Signed 128-bit integer |
-| `uint128` | Unsigned 128-bit integer |
-| `varint32` | Variable-length signed 32-bit integer |
-| `varuint32` | Variable-length unsigned 32-bit integer |
+| `uint8_t` | Boolean (true/false) |
+| `int8_t` | Signed 8-bit integer |
+| `uint8_t` | Unsigned 8-bit integer |
+| `int16_t` | Signed 16-bit integer |
+| `uint16_t` | Unsigned 16-bit integer |
+| `int32_t` | Signed 32-bit integer |
+| `uint32_t` | Unsigned 32-bit integer |
+| `int64_t` | Signed 64-bit integer |
+| `uint64_t` | Unsigned 64-bit integer |
+| `int128_t` | Signed 128-bit integer |
+| `uint128_t` | Unsigned 128-bit integer |
+| `fc::signed_int` | Variable-length signed 32-bit integer |
+| `fc::unsigned_int` | Variable-length unsigned 32-bit integer |
 
 | Float Types | Description |
 | --- | --- |
-| `float32` | 32-bit floating-point number |
-| `float64` | 64-bit floating-point number |
-| `float128` | 128-bit floating-point number |
+| `float` | 32-bit floating-point number |
+| `double` | 64-bit floating-point number |
+| `float128_t` | 128-bit floating-point number |
 
 | Time Types | Description |
 | --- | --- |
-| `time_point` | Point in time |
-| `time_point_sec` | Point in time with second precision |
+| `fc::time_point` | Point in time |
+| `fc::time_point_sec` | Point in time with second precision |
 | `block_timestamp_type` | Block timestamp |
 
 | Name Type | Description |
@@ -265,14 +265,14 @@ This is the full list of built-in types:
 
 | Checksum Types | Description |
 | --- | --- |
-| `checksum160` | 160-bit checksum |
-| `checksum256` | 256-bit checksum |
-| `checksum512` | 512-bit checksum |
+| `checksum160_type` | 160-bit checksum |
+| `checksum256_type` | 256-bit checksum |
+| `checksum512_type` | 512-bit checksum |
 
 | Cryptography Types | Description |
 | --- | --- |
-| `public_key` | Public key |
-| `signature` | Signature |
+| `public_key_type` | Public key |
+| `signature_type` | Signature |
 
 | Asset Types | Description |
 | --- | --- |

--- a/docs/20_smart-contracts/10_getting-started/40_smart_contract_basics.md
+++ b/docs/20_smart-contracts/10_getting-started/40_smart_contract_basics.md
@@ -240,6 +240,7 @@ This is the full list of built-in types:
 | `uint64_t` | Unsigned 64-bit integer |
 | `int128_t` | Signed 128-bit integer |
 | `uint128_t` | Unsigned 128-bit integer |
+| Header file to include | `<eosio/varint.hpp>` |
 | `signed_int` | Variable-length signed 32-bit integer |
 | `unsigned_int` | Variable-length unsigned 32-bit integer |
 
@@ -248,7 +249,6 @@ This is the full list of built-in types:
 | Header file to include | `<eosio/eosio.hpp>` |
 | `float` | 32-bit floating-point number |
 | `double` | 64-bit floating-point number |
-| `float128` | 128-bit floating-point number |
 
 | Time Types | Description |
 | --- | --- |


### PR DESCRIPTION
corrections to show the c++ built-in types instead of their ABI counterparts